### PR TITLE
Add "rest" routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+* Duplicate FeatureServer routes with `rest/services` included between $namespace and $providerParams placeholders. Placeholder get replaced by provider-specific data registration when paired with koop-core ^3.6.0
+* New route `$namespace/rest/info`, for provider-specific information server info
+
 ### Changed
 * Use error.code if available
 

--- a/README.md
+++ b/README.md
@@ -25,28 +25,27 @@ koop.server.listen(80)
 ```js
 [
   {
-    path: 'rest/info',
+    path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo',
-    skipDecoration: true
+    handler: 'featureServerRestInfo'
   },
   {
-    path: 'rest/services/$provider$/FeatureServer/:layer/:method',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'rest/services/$provider$/FeatureServer/layers',
+    path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'rest/services/$provider$/FeatureServer/:layer',
+    path: '$namespace/rest/services/$providerParams/FeatureServer/layers',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'rest/services/$provider$/FeatureServer',
+    path: '$namespace/rest/services/$providerParams/FeatureServer/:layer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: '$namespace$rest/services/$providerParams/FeatureServer',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },

--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ koop.server.listen(80)
 ```js
 [
   {
+    path: 'rest/info',
+    methods: ['get', 'post'],
+    handler: 'featureServerRestInfo',
+    skipDecoration: true
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer/:layer/:method',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer/layers',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer/:layer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
     path: 'FeatureServer/:layer/:method',
     methods: ['get', 'post'],
     handler: 'featureServer'

--- a/index.js
+++ b/index.js
@@ -12,6 +12,26 @@ Geoservices.prototype.featureServer = function (req, res) {
 
 Geoservices.routes = [
   {
+    path: 'rest/services/$provider$/FeatureServer/:layer/:method',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer/layers',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer/:layer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'rest/services/$provider$/FeatureServer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
     path: 'FeatureServer/:layer/:method',
     methods: ['get', 'post'],
     handler: 'featureServer'

--- a/index.js
+++ b/index.js
@@ -10,7 +10,17 @@ Geoservices.prototype.featureServer = function (req, res) {
   })
 }
 
+Geoservices.prototype.featureServerRestInfo = function (req, res) {
+  FeatureServer.route(req, res)
+}
+
 Geoservices.routes = [
+  {
+    path: 'rest/info',
+    methods: ['get', 'post'],
+    handler: 'featureServerRestInfo',
+    skipDecoration: true
+  },
   {
     path: 'rest/services/$provider$/FeatureServer/:layer/:method',
     methods: ['get', 'post'],

--- a/index.js
+++ b/index.js
@@ -16,28 +16,27 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
 
 Geoservices.routes = [
   {
-    path: 'rest/info',
+    path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo',
-    skipDecoration: true
+    handler: 'featureServerRestInfo'
   },
   {
-    path: 'rest/services/$provider$/FeatureServer/:layer/:method',
-    methods: ['get', 'post'],
-    handler: 'featureServer'
-  },
-  {
-    path: 'rest/services/$provider$/FeatureServer/layers',
+    path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'rest/services/$provider$/FeatureServer/:layer',
+    path: '$namespace/rest/services/$providerParams/FeatureServer/layers',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
   {
-    path: 'rest/services/$provider$/FeatureServer',
+    path: '$namespace/rest/services/$providerParams/FeatureServer/:layer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: '$namespace/rest/services/$providerParams/FeatureServer',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   },
   "homepage": "https://github.com/koopjs/koop-output-geoservices#readme",
   "devDependencies": {
-    "standard": "^10.0.0"
+    "standard": "^11.0.1"
   },
   "dependencies": {
     "featureserver": "*"
   },
   "peerDependencies": {
-   "koop": "^3.4.0"
+    "koop": "^3.6.0"
   }
 }


### PR DESCRIPTION
Some ArcGIS clients require the inclusion of `rest/services` within the route path, otherwise they are rejected.  Similarly, these clients may require a `rest/info` route.

This PR adds a duplicate set of service routes with a `$namespace/rest/services/$providerParams` prefix.  A companion update to koop-core will include code to replace the `$namespace`  and `$providerParams` with the provider-specific route fragments.

Additionally, a `$namespace/rest/info` route is added along with a target handler. 