### PR TITLE
Add properties to `/rest/info` route object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unrelease
-### Added
+### Fixed
 * Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.
 
 ## [1.2.0] - 2018-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unrelease
+### Added
+* Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.
+
 ## [1.2.0] - 2018-04-27
 ### Added
 * Duplicate FeatureServer routes with `rest/services` included between $namespace and $providerParams placeholders. Placeholder get replaced by provider-specific data registration when paired with koop-core ^3.6.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ koop.server.listen(80)
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo'
+    handler: 'featureServerRestInfo',
+    hosts: false,
+    disableIdParam: true
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',

--- a/index.js
+++ b/index.js
@@ -16,19 +16,24 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
 
 /**
  * Collection of route objects that define geoservices
- * 
- * These routes are bound to the Koop API for each provider. Note that FeatureServer, 
- * FeatureServer/layers, FeatureServer/:layer, and FeatureServer/:layer/:method are found 
+ *
+ * These routes are bound to the Koop API for each provider. Note that FeatureServer,
+ * FeatureServer/layers, FeatureServer/:layer, and FeatureServer/:layer/:method are found
  * in the collection with and without the "$namespace/rest/services/$providerParams" prefix.
- * These prefixed routes have been added due to some clients requiring the "rest/services" 
- * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders 
- * that koop-core replaces with provider specific settings.  
+ * These prefixed routes have been added due to some clients requiring the "rest/services"
+ * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders
+ * that koop-core replaces with provider-specific settings. The 'host' and 'disableIdParam'
+ * properties of a route object will override the properties of the provider - thus, in the
+ * example below '$namespace/rest/info' is not transformed into '$namespace/:host/:id/rest/info
+ * if a provider's 'host' property is true.
  */
 Geoservices.routes = [
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo'
+    handler: 'featureServerRestInfo',
+    hosts: false,
+    disableIdParam: true
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',


### PR DESCRIPTION
Add properties to `$namespace/rest/info` route object to prevent the addition of `:host` and `:id` parameters to the route path.