### PR TITLE
Pass authentication info from provider to FeatureServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ###Added
-* Call model function `authInfo` (if exists) in the `rest/info` handler and pass returned object onto FeatureServer
+* Call model function `authInfo` (if exists) in the `rest/info` handler and pass returned object to FeatureServer
 
 ### Fixed
 * Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unrelease
+## Unreleased
+###Added
+* Call model function `authInfo` (if exists) in the `rest/info` handler and pass returned object onto FeatureServer
+
 ### Fixed
 * Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ###Added
-* Call model function `authInfo` (if exists) in the `rest/info` handler and pass returned object to FeatureServer
+* Call model function `authenticationSpecification` (if exists) in the `rest/info` handler and pass data to FeatureServer
 
 ### Fixed
 * Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unrelease
-### Added
+### Fixed
 * Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.
 
 ## [1.2.0] - 2018-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unrelease
+### Added
+* Route intended to be `$namespace/rest/info` was being generated as `$namespace/:host/:id/rest/info`.  Added additional parameters to route object (`hosts` and `disableIdParams`) that allow koop-core to override provider settings to prevent unwanted parameter addition.
+
 ## [1.2.0] - 2018-04-27
 ### Added
 * Duplicate FeatureServer routes with `rest/services` included between $namespace and $providerParams placeholders. Placeholder get replaced by provider-specific data registration when paired with koop-core ^3.6.0

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ koop.server.listen(80)
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo',
-    hosts: false,
-    disableIdParam: true
+    handler: 'featureServerRestInfo'
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ koop.server.listen(80)
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo'
+    handler: 'featureServerRestInfo',
+    hosts: false,
+    disableIdParam: true
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',

--- a/index.js
+++ b/index.js
@@ -16,19 +16,24 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
 
 /**
  * Collection of route objects that define geoservices
- * 
- * These routes are bound to the Koop API for each provider. Note that FeatureServer, 
- * FeatureServer/layers, FeatureServer/:layer, and FeatureServer/:layer/:method are found 
+ *
+ * These routes are bound to the Koop API for each provider. Note that FeatureServer,
+ * FeatureServer/layers, FeatureServer/:layer, and FeatureServer/:layer/:method are found
  * in the collection with and without the "$namespace/rest/services/$providerParams" prefix.
- * These prefixed routes have been added due to some clients requiring the "rest/services" 
- * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders 
- * that koop-core replaces with provider specific settings.  
+ * These prefixed routes have been added due to some clients requiring the "rest/services"
+ * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders
+ * that koop-core replaces with provider-specific settings. The 'host' and 'disableIdParam'
+ * properties of a route object will override the properties of the provider - thus, in the
+ * example below '$namespace/rest/info' is not transformed into '$namespace/:host/:id/rest/info
+ * if a provider's 'host' property is true.
  */
 Geoservices.routes = [
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo'
+    handler: 'featureServerRestInfo',
+    hosts: false,
+    disableIdParam: true
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FeatureServer = require('../FeatureServer/src')
+var FeatureServer = require('featureserver')
 
 function Geoservices () {}
 
@@ -11,14 +11,14 @@ Geoservices.prototype.featureServer = function (req, res) {
 }
 
 /**
- * Handler for the $namepace/rest/info route. Inspects provider for authentation info and passes any on to the 
+ * Handler for the $namepace/rest/info route. Inspects provider for authentation info and passes any on to the
  * FeatureServer handler
- * @param {*} req 
- * @param {*} res 
+ * @param {*} req
+ * @param {*} res
  */
 Geoservices.prototype.featureServerRestInfo = function (req, res) {
   // Inspect provider for an "authInfo" controller; if undefined create a dummy function that returns an empty object
-  let authInfo = this.authInfo || function() { return {} }
+  let authInfo = this.authInfo || function () { return {} }
   FeatureServer.route(req, res, authInfo(`${req.protocol}://${req.headers.host}`))
 }
 

--- a/index.js
+++ b/index.js
@@ -30,18 +30,13 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
  * in the collection with and without the "$namespace/rest/services/$providerParams" prefix.
  * These prefixed routes have been added due to some clients requiring the "rest/services"
  * URL fragment in geoservices routes. The $namespace and $providerParams are placeholders
- * that koop-core replaces with provider-specific settings. The 'host' and 'disableIdParam'
- * properties of a route object will override the properties of the provider - thus, in the
- * example below '$namespace/rest/info' is not transformed into '$namespace/:host/:id/rest/info
- * if a provider's 'host' property is true.
+ * that koop-core replaces with provider-specific settings.
  */
 Geoservices.routes = [
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
-    handler: 'featureServerRestInfo',
-    hosts: false,
-    disableIdParam: true
+    handler: 'featureServerRestInfo'
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
   let authSpec = getAuthSpec()
   if (authSpec.secured) {
     authInfo.isTokenBasedSecurity = true
-    authInfo.tokenServicesUrl = `${req.protocol}://${req.headers.host}/${authSpec.provider}/generateToken`
+    authInfo.tokenServicesUrl = `${req.protocol}://${req.headers.host}/${authSpec.provider}/rest/generateToken`
   }
   FeatureServer.route(req, res, { authInfo })
 }
@@ -54,7 +54,7 @@ Geoservices.routes = [
     handler: 'featureServerRestInfo'
   },
   {
-    path: '$namespace/generateToken',
+    path: '$namespace/rest/generateToken',
     methods: ['get', 'post'],
     handler: 'generateToken'
   },

--- a/index.js
+++ b/index.js
@@ -11,15 +11,24 @@ Geoservices.prototype.featureServer = function (req, res) {
 }
 
 /**
- * Handler for the $namepace/rest/info route. Inspects provider for authentation info and passes any on to the
+ * Handler for the $namepace/rest/info route. Inspects model for authentation info and passes any on to the
  * FeatureServer handler
  * @param {*} req
  * @param {*} res
  */
 Geoservices.prototype.featureServerRestInfo = function (req, res) {
-  // Inspect provider for an "authInfo" controller; if undefined create a dummy function that returns an empty object
-  let authInfo = this.authInfo || function () { return {} }
-  FeatureServer.route(req, res, authInfo(`${req.protocol}://${req.headers.host}`))
+  // Inspect model for an "serviceAuthenticationSpecification" function; if undefined create a dummy function that returns an empty object
+  let authSpecs = this.model.serviceAuthenticationSpecification || function () { return {} }
+  FeatureServer.route(req, res, authSpecs(`${req.protocol}://${req.headers.host}`))
+}
+
+/**
+ * Handler for $namespace/authenticate route. Passes request and response object to the model's "authenticate" function
+ * @param {*} req
+ * @param {*} res
+ */
+Geoservices.prototype.authenticate = function (req, res) {
+  this.model.authenticate(req, res)
 }
 
 /**
@@ -37,6 +46,11 @@ Geoservices.routes = [
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
     handler: 'featureServerRestInfo'
+  },
+  {
+    path: '$namespace/authenticate',
+    methods: ['get', 'post'],
+    handler: 'authenticate'
   },
   {
     path: '$namespace/rest/services/$providerParams/FeatureServer/:layer/:method',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FeatureServer = require('featureserver')
+var FeatureServer = require('../FeatureServer/src')
 
 function Geoservices () {}
 
@@ -11,7 +11,8 @@ Geoservices.prototype.featureServer = function (req, res) {
 }
 
 Geoservices.prototype.featureServerRestInfo = function (req, res) {
-  FeatureServer.route(req, res)
+  let authInfo = this.generateAuthInfo || function() { return {} }
+  FeatureServer.route(req, res, authInfo(req))
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -10,9 +10,16 @@ Geoservices.prototype.featureServer = function (req, res) {
   })
 }
 
+/**
+ * Handler for the $namepace/rest/info route. Inspects provider for authentation info and passes any on to the 
+ * FeatureServer handler
+ * @param {*} req 
+ * @param {*} res 
+ */
 Geoservices.prototype.featureServerRestInfo = function (req, res) {
-  let authInfo = this.generateAuthInfo || function() { return {} }
-  FeatureServer.route(req, res, authInfo(req))
+  // Inspect provider for an "authInfo" controller; if undefined create a dummy function that returns an empty object
+  let authInfo = this.authInfo || function() { return {} }
+  FeatureServer.route(req, res, authInfo(`${req.protocol}://${req.headers.host}`))
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "featureserver": "*"
   },
   "peerDependencies": {
-    "koop": "^3.6.0"
+    "koop": "^3.6.1"
   }
 }


### PR DESCRIPTION
* In handler for `provider/rest/info` route, attempt to access/assign the provider's `authInfo` controller; if it doesn't exist, assign a dummy function that returns an empty object

* execute the `authInfo` function in the handler and pass on the returned object to FeatureServer