### PR TITLE
WIP: Implement authentication and authorization handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added handling of authorization and authentication errors
+
 ## [1.3.0] - 2018-05-17
 ### Added
 * Call model function `authenticationSpecification` (if exists) in the `rest/info` handler and pass data to FeatureServer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-### Added handling of authorization and authentication errors
+### Added 
+* handling of authorization and authentication errors
+
+### Fixed
+* Bump FeatureServer version to 2.14.0 in order to support added authentication handling
 
 ## [1.3.0] - 2018-05-17
 ### Added

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ Geoservices.prototype.featureServer = async function (req, res) {
   if (typeof this.model.validateToken === 'function') {
     try {
       // Does request have a valid authorization token?
-      await this.model.validateToken(req.query.token)
+      await this.model.authorize(req.query.token)
     } catch (err) {
       // Respond with an authorization error
       return FeatureServer.error.authorization(res)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FeatureServer = require('../FeatureServer/src')
+var FeatureServer = require('featureserver')
 
 function Geoservices () {}
 
@@ -49,7 +49,7 @@ Geoservices.prototype.generateToken = async function (req, res) {
     try {
       // Does request successfully authenticate?
       let tokenJson = await this.model.authenticate(req.query.username, req.query.password)
-      // Pass on to FeatureServer for request response formatting 
+      // Pass on to FeatureServer for request response formatting
       FeatureServer.authenticate(res, tokenJson)
     } catch (err) {
       // Respond with an authentication error

--- a/index.js
+++ b/index.js
@@ -2,7 +2,17 @@ var FeatureServer = require('featureserver')
 
 function Geoservices () {}
 
-Geoservices.prototype.featureServer = function (req, res) {
+Geoservices.prototype.featureServer = async function (req, res) {
+  // Is model configured for token-authorization?
+  if (typeof this.model.validateToken === 'function') {
+    try {
+      // Does request have a valid authorization token?
+      await this.model.validateToken(req.query.token)
+    } catch (err) {
+      // Respond with an authorization error
+      return FeatureServer.error.authorization(res)
+    }
+  }
   // model will be available when this is instantiated with the Koop controller
   this.model.pull(req, function (err, data) {
     if (err) res.status(err.code || 500).json({error: err.message})
@@ -33,8 +43,17 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
  * @param {*} req
  * @param {*} res
  */
-Geoservices.prototype.generateToken = function (req, res) {
-  this.model.authenticate(req, res)
+Geoservices.prototype.generateToken = async function (req, res) {
+  // Is model configured for authentication?
+  if (typeof this.model.authenticate === 'function') {
+    try {
+      // Does request successfully authenticate?
+      await this.model.authenticate(req, res)
+    } catch (err) {
+      // Respond with an authentication error
+      return FeatureServer.error.authentication(res)
+    }
+  }
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-var FeatureServer = require('featureserver')
+var FeatureServer = require('../FeatureServer/src')
 
 function Geoservices () {}
 
 Geoservices.prototype.featureServer = async function (req, res) {
   // Is model configured for token-authorization?
-  if (typeof this.model.validateToken === 'function') {
+  if (typeof this.model.authorize === 'function') {
     try {
       // Does request have a valid authorization token?
       await this.model.authorize(req.query.token)
@@ -48,7 +48,9 @@ Geoservices.prototype.generateToken = async function (req, res) {
   if (typeof this.model.authenticate === 'function') {
     try {
       // Does request successfully authenticate?
-      await this.model.authenticate(req, res)
+      let tokenJson = await this.model.authenticate(req.query.username, req.query.password)
+      // Pass on to FeatureServer for request response formatting 
+      FeatureServer.authenticate(res, tokenJson)
     } catch (err) {
       // Respond with an authentication error
       return FeatureServer.error.authentication(res)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "standard": "^11.0.1"
   },
   "dependencies": {
-    "featureserver": "^2.13.0"
+    "featureserver": "^2.14.0"
   },
   "peerDependencies": {
     "koop": "^3.6.1"


### PR DESCRIPTION
Use Model.Prototype.authorize to authorize data requests.  Use Model.Prototype.authenticate to handle requests to `provider/rest/generateToken`.  Pass on errors from either to FeatureServer.