### PR TITLE
Change remove `generateToken` from `rest/info` response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,19 @@ koop.server.listen(80)
 ## Routes
 
 ```js
-[
+Geoservices.routes = [
   {
     path: '$namespace/rest/info',
     methods: ['get', 'post'],
     handler: 'featureServerRestInfo'
   },
   {
-    path: '$namespace/rest/generateToken',
+    path: '$namespace/tokens/:method',
+    methods: ['get', 'post'],
+    handler: 'generateToken'
+  },
+  {
+    path: '$namespace/tokens/',
     methods: ['get', 'post'],
     handler: 'generateToken'
   },
@@ -50,7 +55,7 @@ koop.server.listen(80)
     handler: 'featureServer'
   },
   {
-    path: '$namespace/$rest/services/$providerParams/FeatureServer',
+    path: '$namespace/rest/services/$providerParams/FeatureServer',
     methods: ['get', 'post'],
     handler: 'featureServer'
   },
@@ -71,6 +76,26 @@ koop.server.listen(80)
   },
   {
     path: 'FeatureServer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: '$namespace/rest/services/$providerParams/FeatureServer*',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'FeatureServer*',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: '$namespace/rest/services/$providerParams/MapServer*',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'MapServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FeatureServer = require('../FeatureServer/src')
+var FeatureServer = require('featureserver')
 
 console.log('WARNING: "/MapServer" routes will be registered, but only for specialized 404 handling in FeatureServer.')
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-var FeatureServer = require('featureserver')
+var FeatureServer = require('../FeatureServer/src')
+
+console.log('WARNING: "/MapServer" routes will be registered, but only for specialized 404 handling in FeatureServer.')
 
 function Geoservices () {}
 
@@ -29,7 +31,7 @@ Geoservices.prototype.featureServer = function (req, res) {
         pullDataAndRoute(this.model, req, res)
       })
       .catch(err => {
-        if (err.code === 401) FeatureServer.error.authorization(res)
+        if (err.code === 401) FeatureServer.error.authorization(req, res)
         else res.status(err.code || 500).json({error: err.message})
       })
   } else {
@@ -50,7 +52,7 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
   let authSpec = getAuthSpec()
   if (authSpec.secured) {
     authInfo.isTokenBasedSecurity = true
-    authInfo.tokenServicesUrl = `${req.protocol}://${req.headers.host}/${authSpec.provider}/rest/generateToken`
+    authInfo.tokenServicesUrl = `${req.protocol}://${req.headers.host}/${authSpec.provider}/tokens/`
   }
   FeatureServer.route(req, res, { authInfo })
 }
@@ -68,7 +70,7 @@ Geoservices.prototype.generateToken = function (req, res) {
         FeatureServer.authenticate(res, tokenJson)
       })
       .catch(err => {
-        if (err.code === 401) FeatureServer.error.authentication(res)
+        if (err.code === 401) FeatureServer.error.authentication(req, res)
         else res.status(err.code || 500).json({error: err.message})
       })
   } else {
@@ -93,7 +95,12 @@ Geoservices.routes = [
     handler: 'featureServerRestInfo'
   },
   {
-    path: '$namespace/rest/generateToken',
+    path: '$namespace/tokens/:method',
+    methods: ['get', 'post'],
+    handler: 'generateToken'
+  },
+  {
+    path: '$namespace/tokens/',
     methods: ['get', 'post'],
     handler: 'generateToken'
   },
@@ -134,6 +141,26 @@ Geoservices.routes = [
   },
   {
     path: 'FeatureServer',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: '$namespace/rest/services/$providerParams/FeatureServer*',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'FeatureServer*',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: '$namespace/rest/services/$providerParams/MapServer*',
+    methods: ['get', 'post'],
+    handler: 'featureServer'
+  },
+  {
+    path: 'MapServer*',
     methods: ['get', 'post'],
     handler: 'featureServer'
   }


### PR DESCRIPTION
* Route token-services-url requests to same handler, with or without `generateToken` method parameter
* Pass on request objects to authentication/authorization error handling, so as to handle `callback` query parameters
* Add route handling for all MapServer and other FeatureServer requests, to enable proper 404 error handling when callback parameter is specified.