### PR TITLE
Use https by default when constructing the tokenServicesUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Use `https` as the default protocol when constructing the `tokenServicesUrl` in the `featureServerRestInfo` handler. Default is overridden when an `ssl` property is defined on the result of `authenticationSpecification()`
+* Added base-url fragment to `tokenServicesUrl`
+
 ## [1.4.2] - 2018-05-23
 ### Fixed
 * missed FeatureServer handling of authentication error

--- a/index.js
+++ b/index.js
@@ -52,7 +52,9 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
   let authSpec = getAuthSpec()
   if (authSpec.secured) {
     authInfo.isTokenBasedSecurity = true
-    authInfo.tokenServicesUrl = `${req.protocol}://${req.headers.host}/${authSpec.provider}/tokens/`
+    // Use https by default, unless an authSpec.ssl property is defined and set to true
+    let protocol = (authSpec.ssl === true || typeof authSpec.ssl === 'undefined') ? 'https' : 'http'
+    authInfo.tokenServicesUrl = `${protocol}://${req.headers.host}${req.baseUrl}/${authSpec.provider}/tokens/`
   }
   FeatureServer.route(req, res, { authInfo })
 }


### PR DESCRIPTION
Use https by default when constructing the tokenServicesUrl.  Allow the default to be overridden by authenticationSpecification property "ssl".