### PR TITLE
Pass in request object to authorization and authentication functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Pass Express request object as argument in calls to `this.model.authorize` and `this.model.authenticate`
+
 ## [1.5.2] - 2018-06-08
 ### Fixed
 * Simplify acquisition of authentication specification from Model.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function pullDataAndRoute (model, req, res) {
 Geoservices.prototype.featureServer = function (req, res) {
   // Is model configured for token-authorization?
   if (typeof this.model.authorize === 'function') {
-    this.model.authorize(req.query.token)
+    this.model.authorize(req)
       .then(valid => {
         // model will be available when this is instantiated with the Koop controller
         pullDataAndRoute(this.model, req, res)
@@ -65,7 +65,7 @@ Geoservices.prototype.featureServerRestInfo = function (req, res) {
 Geoservices.prototype.generateToken = function (req, res) {
   // Is model configured for authentication?
   if (typeof this.model.authenticate === 'function') {
-    this.model.authenticate(req.query.username, req.query.password)
+    this.model.authenticate(req)
       .then(tokenJson => {
         FeatureServer.authenticate(res, tokenJson)
       })


### PR DESCRIPTION
To provide more flexibility to auth plugins, the full request object is passed into the `authorize` and `authentication` functions.  This change will break auth plugins that require koop-output-geoservices as a peer dependencies - so while this is a small change, this should probably be a major version bump.