### PR TITLE
Normalize error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
+## [2.0.1] - 2020-10-15
+### Fixed
+* Ensure error codes are numbers before being passed on to handler; string codes result in unhandled errors.
 
 ## [2.0.0] - 2018-09-04
 ### Changed


### PR DESCRIPTION
Ensure error codes are numbers before being passed on to handler; string codes currently result in unhandled errors and a request timeout.