### PR TITLE
Allow koop peer dependency >= 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "featureserver": "^3.2.0"
   },
   "peerDependencies": {
-    "koop": "^3.6.1"
+    "koop": ">=3.6.1"
   }
 }


### PR DESCRIPTION
The `koop@^3.6.1` peer dependency can cause old versions of koop to creep into the NPM dependency tree when using more recent versions of koop. When this happens, `koop@3.6.1` introduces additional unnecessary dependencies into the tree including an older version of this plugin.

To avoid this dependency creep, I updated the peer dependency to include newer versions of koop. To my knowledge, the latest version of koop (4.2.1) is fully compatible with this plugin.