### PR TITLE
Patch for Node versions below 14.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* make access of authInfo compatible with Node.js version lower than 14
 ## [3.1.1] - 2022-01-18
 ### Changed
 * Peer dependency
@@ -106,25 +109,25 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.0.0] - 2017-01-25
 * Initial Release
 
-[3.1.1]: https://github.com/koopjs/koop-featureserver-plugin/compare/v3.1.0...v3.1.1
-[3.1.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v3.0.0...v3.1.0
-[3.0.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.2.1...v3.0.0
-[2.2.1]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.2.0...v2.2.1
-[2.2.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.1.0...v2.2.0
-[2.1.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.0.3...v2.1.0
-[2.0.3]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.0.2...v2.0.3
-[2.0.2]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/koopjs/koop-featureserver-plugin/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.5.2...v2.0.0
-[1.5.2]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.5.1...v1.5.2
-[1.5.1]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.5.0...v1.5.1
-[1.5.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.4.2...v1.5.0
-[1.4.2]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.4.1...v1.4.2
-[1.4.1]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.4.0...v1.4.1
-[1.4.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.1.2...v1.2.0
-[1.1.2]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/koopjs/koop-featureserver-plugin/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/koopjs/koop-featureserver-plugin/releases/tag/v1.0.0
+[3.1.1]: https://github.com/koopjs/koop-output-geoservices/compare/v3.1.0...v3.1.1
+[3.1.0]: https://github.com/koopjs/koop-output-geoservices/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/koopjs/koop-output-geoservices/compare/v2.2.1...v3.0.0
+[2.2.1]: https://github.com/koopjs/koop-output-geoservices/compare/v2.2.0...v2.2.1
+[2.2.0]: https://github.com/koopjs/koop-output-geoservices/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/koopjs/koop-output-geoservices/compare/v2.0.3...v2.1.0
+[2.0.3]: https://github.com/koopjs/koop-output-geoservices/compare/v2.0.2...v2.0.3
+[2.0.2]: https://github.com/koopjs/koop-output-geoservices/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/koopjs/koop-output-geoservices/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/koopjs/koop-output-geoservices/compare/v1.5.2...v2.0.0
+[1.5.2]: https://github.com/koopjs/koop-output-geoservices/compare/v1.5.1...v1.5.2
+[1.5.1]: https://github.com/koopjs/koop-output-geoservices/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/koopjs/koop-output-geoservices/compare/v1.4.2...v1.5.0
+[1.4.2]: https://github.com/koopjs/koop-output-geoservices/compare/v1.4.1...v1.4.2
+[1.4.1]: https://github.com/koopjs/koop-output-geoservices/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/koopjs/koop-output-geoservices/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/koopjs/koop-output-geoservices/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/koopjs/koop-output-geoservices/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/koopjs/koop-output-geoservices/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/koopjs/koop-output-geoservices/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/koopjs/koop-output-geoservices/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/koopjs/koop-output-geoservices/releases/tag/v1.0.0

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ Geoservices.prototype.featureServer = function (req, res) {
  * @param {object} res response object
  */
 Geoservices.prototype.featureServerRestInfo = function (req, res) {
-  const authInfo = koopConfig?.authInfo || {};
+  const authInfo = koopConfig && koopConfig.authInfo || {};
   const authSpec = this.model.authenticationSpecification
   if (authSpec) {
     authInfo.isTokenBasedSecurity = true


### PR DESCRIPTION
The PR https://github.com/koopjs/koop-output-geoservices/commit/bef780e051da629a451909aa3bda970b751fe9a3 that allows for sourcing `authInfo` to the config was not compatible with Node versions prior to 14.  This causes a fatal error in such environments.  This PR includes a one-line fix to patch.

cc @rsjones 